### PR TITLE
feature: Discord Rich Presence integration with cover art and action buttons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "rox"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -5480,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "rox-dock"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "gpui",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "rox-library"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "image",
  "lofty",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "rox-playback"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "cpal",
  "log",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "rox-viz"
-version = "1.5.1"
+version = "1.5.2"
 
 [[package]]
 name = "roxmltree"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "discord-rich-presence"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c55d69cab17c19677ce3a5f8face993a9e6eaf847fecac3547f3a3ff4a2494"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "uuid 0.8.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,7 +2520,7 @@ dependencies = [
  "taffy",
  "thiserror 2.0.18",
  "usvg",
- "uuid",
+ "uuid 1.23.4",
  "waker-fn",
  "wayland-backend",
  "wayland-client",
@@ -2558,7 +2573,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-json",
  "unicode-segmentation",
- "uuid",
+ "uuid 1.23.4",
  "zed-sum-tree",
 ]
 
@@ -5438,6 +5453,7 @@ dependencies = [
  "async-channel 2.5.0",
  "chrono",
  "dirs 5.0.1",
+ "discord-rich-presence",
  "gpui",
  "gpui-component",
  "gpui-component-assets",
@@ -7472,6 +7488,15 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "uuid"
 version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
@@ -8733,7 +8758,7 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "uuid",
+ "uuid 1.23.4",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
  "zbus_macros 5.17.0",

--- a/crates/rox/Cargo.toml
+++ b/crates/rox/Cargo.toml
@@ -57,6 +57,8 @@ trash = "5"
 # transport; percent-encodes the path so spaces and unicode survive. Already
 # in the tree, same 2.x line.
 url = "2"
+# Rich Prescence for Discord
+discord-rich-presence = "1.x"
 
 # The quit-to-tray icon: StatusNotifierItem over D-Bus, pure Rust on the
 # same zbus 5 line souvlaki brought in. Runtime-agnostic via async-io

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -25,7 +25,7 @@ pub enum DiscordCommand {
 }
 
 /// Snapshot of the currently playing track state sent over channel.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DiscordTrackState {
     pub title: String,
     pub artist: String,
@@ -39,8 +39,9 @@ pub struct DiscordTrackState {
     pub show_youtube_button: bool,
 }
 
-impl PartialEq for DiscordTrackState {
-    fn eq(&self, other: &Self) -> bool {
+impl DiscordTrackState {
+    /// Compare all track metadata fields except position_secs (which updates continuously).
+    pub fn same_metadata(&self, other: &Self) -> bool {
         self.title == other.title
             && self.artist == other.artist
             && self.album == other.album
@@ -186,13 +187,7 @@ impl DiscordPresence {
             (None, Some(_)) => true,
             (Some(_), None) => true,
             (Some(prev), Some(curr)) => {
-                let metadata_changed = prev.title != curr.title
-                    || prev.artist != curr.artist
-                    || prev.album != curr.album
-                    || prev.duration_secs != curr.duration_secs
-                    || prev.is_playing != curr.is_playing;
-
-                if metadata_changed {
+                if !prev.same_metadata(curr) {
                     true
                 } else if curr.is_playing {
                     // Detect manual user seek (> 3s drift from elapsed clock)

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -55,6 +55,7 @@ impl DiscordTrackState {
 }
 
 pub struct DiscordPresence {
+    player: Entity<Player>,
     library: Entity<Library>,
     config: DiscordSettings,
     sender: async_channel::Sender<DiscordCommand>,
@@ -87,6 +88,7 @@ impl DiscordPresence {
         info!("Discord Rich Presence initialized");
 
         Self {
+            player: player.clone(),
             library: library.clone(),
             config: Settings::load().discord,
             sender: tx,
@@ -97,22 +99,16 @@ impl DiscordPresence {
         }
     }
 
-    /// Refresh settings from the active configuration.
-    pub fn reload_config(&mut self) {
+    /// Refresh settings from the active configuration and force immediate presence update.
+    pub fn reload_config(&mut self, cx: &mut Context<Self>) {
         self.config = Settings::load().discord;
         info!(
-            "Discord RPC settings reloaded: enabled={}, timestamps={}, details={}",
-            self.config.enabled, self.config.show_timestamps, self.config.show_details
+            "Discord RPC settings reloaded: enabled={}, lastfm_button={}, youtube_button={}",
+            self.config.enabled, self.config.show_lastfm_button, self.config.show_youtube_button
         );
-        if !self.config.enabled {
-            self.last_sent_track = None;
-            self.last_sent_time = None;
-            info!("Discord RPC disabled via settings; clearing presence immediately");
-            let _ = self.sender.try_send(DiscordCommand::ClearPresence);
-        } else {
-            // Force update on next tick
-            self.last_sent_track = None;
-        }
+        self.last_sent_track = None;
+        let player = self.player.clone();
+        self.tick(&player, cx);
     }
 
     /// React to player pump notifications on the main thread.
@@ -264,7 +260,7 @@ impl DiscordPresence {
                             .details(&details)
                             .state(&state_str);
 
-                        // Add timestamp if enabled and playing
+                        // Add timestamp if playing
                         if state.is_playing {
                             let now_millis = SystemTime::now()
                                 .duration_since(UNIX_EPOCH)

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -35,7 +35,8 @@ pub struct DiscordTrackState {
     pub position_secs: f64,
     pub duration_secs: Option<f64>,
     pub is_playing: bool,
-    pub show_button: bool,
+    pub show_lastfm_button: bool,
+    pub show_youtube_button: bool,
 }
 
 impl PartialEq for DiscordTrackState {
@@ -47,7 +48,8 @@ impl PartialEq for DiscordTrackState {
             && self.bitrate_kbps == other.bitrate_kbps
             && self.duration_secs == other.duration_secs
             && self.is_playing == other.is_playing
-            && self.show_button == other.show_button
+            && self.show_lastfm_button == other.show_lastfm_button
+            && self.show_youtube_button == other.show_youtube_button
     }
 }
 
@@ -166,7 +168,8 @@ impl DiscordPresence {
                 position_secs: now.position_secs,
                 duration_secs: now.duration_secs,
                 is_playing,
-                show_button: self.config.show_button,
+                show_lastfm_button: self.config.show_lastfm_button,
+                show_youtube_button: self.config.show_youtube_button,
             }
         });
 
@@ -322,6 +325,7 @@ impl DiscordPresence {
                         activity = activity.assets(assets);
 
                         // Add clickable buttons if enabled and artist/title available
+                        let mut buttons = Vec::new();
                         let lastfm_url = format!(
                             "https://www.last.fm/music/{}/_/{}",
                             url_encode(&state.artist),
@@ -332,13 +336,17 @@ impl DiscordPresence {
                             url_encode(&state.artist),
                             url_encode(&state.title)
                         );
-                        if state.show_button
-                            && (!state.artist.is_empty() || !state.title.is_empty())
-                        {
-                            activity = activity.buttons(vec![
-                                Button::new("View on Last.fm", &lastfm_url),
-                                Button::new("Search on YouTube", &youtube_url),
-                            ]);
+                        let has_meta = !state.artist.is_empty() || !state.title.is_empty();
+
+                        if state.show_lastfm_button && has_meta {
+                            buttons.push(Button::new("View on Last.fm", &lastfm_url));
+                        }
+                        if state.show_youtube_button && has_meta {
+                            buttons.push(Button::new("Search on YouTube", &youtube_url));
+                        }
+
+                        if !buttons.is_empty() {
+                            activity = activity.buttons(buttons);
                         }
 
                         if let Err(e) = cli.set_activity(activity) {

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -9,6 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use discord_rich_presence::activity::{Activity, ActivityType, Assets, Timestamps};
 use discord_rich_presence::{DiscordIpc, DiscordIpcClient};
 use gpui::{Context, Entity, Subscription};
+use log::{error, info, warn};
 
 use crate::panels::library::Library;
 use crate::player::Player;
@@ -24,7 +25,7 @@ pub enum DiscordCommand {
 }
 
 /// Snapshot of the currently playing track state sent over channel.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct DiscordTrackState {
     pub title: String,
     pub artist: String,
@@ -34,11 +35,25 @@ pub struct DiscordTrackState {
     pub is_playing: bool,
 }
 
+impl PartialEq for DiscordTrackState {
+    fn eq(&self, other: &Self) -> bool {
+        self.title == other.title
+            && self.artist == other.artist
+            && self.album == other.album
+            && self.duration_secs == other.duration_secs
+            && self.is_playing == other.is_playing
+            // Only consider state changed if position jumped/seeked by more than 2 seconds
+            && (self.position_secs - other.position_secs).abs() < 2.0
+    }
+}
+
 pub struct DiscordPresence {
     library: Entity<Library>,
     config: DiscordSettings,
     sender: async_channel::Sender<DiscordCommand>,
-    last_state: Option<DiscordTrackState>,
+    last_sent_track: Option<DiscordTrackState>,
+    last_sent_time: Option<SystemTime>,
+    last_sent_position: f64,
     _player_changed: Subscription,
 }
 
@@ -62,11 +77,15 @@ impl DiscordPresence {
             this.tick(&player, cx);
         });
 
+        info!("Discord Rich Presence initialized");
+
         Self {
             library: library.clone(),
             config: Settings::load().discord,
             sender: tx,
-            last_state: None,
+            last_sent_track: None,
+            last_sent_time: None,
+            last_sent_position: 0.0,
             _player_changed,
         }
     }
@@ -74,13 +93,21 @@ impl DiscordPresence {
     /// Refresh settings from the active configuration.
     pub fn reload_config(&mut self) {
         self.config = Settings::load().discord;
+        info!(
+            "Discord RPC settings reloaded: enabled={}, timestamps={}, details={}",
+            self.config.enabled, self.config.show_timestamps, self.config.show_details
+        );
+        // Force update on next tick
+        self.last_sent_track = None;
     }
 
     /// React to player pump notifications on the main thread.
     fn tick(&mut self, player: &Entity<Player>, cx: &mut Context<Self>) {
         if !self.config.enabled {
-            if self.last_state.is_some() {
-                self.last_state = None;
+            if self.last_sent_track.is_some() {
+                self.last_sent_track = None;
+                self.last_sent_time = None;
+                info!("Discord RPC disabled; clearing presence");
                 let _ = self.sender.try_send(DiscordCommand::ClearPresence);
             }
             return;
@@ -129,9 +156,45 @@ impl DiscordPresence {
             })
         });
 
-        // State gating: avoid redundant updates if track state hasn't moved
-        if self.last_state != current_state {
-            self.last_state = current_state.clone();
+        let now_time = SystemTime::now();
+
+        let should_update = match (&self.last_sent_track, &current_state) {
+            (None, Some(_)) => true,
+            (Some(_), None) => true,
+            (Some(prev), Some(curr)) => {
+                let metadata_changed = prev.title != curr.title
+                    || prev.artist != curr.artist
+                    || prev.album != curr.album
+                    || prev.duration_secs != curr.duration_secs
+                    || prev.is_playing != curr.is_playing;
+
+                if metadata_changed {
+                    true
+                } else if curr.is_playing {
+                    // Detect manual user seek (> 3s drift from elapsed clock)
+                    let elapsed_real = self
+                        .last_sent_time
+                        .and_then(|t| now_time.duration_since(t).ok())
+                        .map(|d| d.as_secs_f64())
+                        .unwrap_or(0.0);
+                    let expected_pos = self.last_sent_position + elapsed_real;
+                    (curr.position_secs - expected_pos).abs() > 3.0
+                } else {
+                    false
+                }
+            }
+            (None, None) => false,
+        };
+
+        if should_update {
+            self.last_sent_track = current_state.clone();
+            self.last_sent_time = if current_state.is_some() {
+                Some(now_time)
+            } else {
+                None
+            };
+            self.last_sent_position = current_state.as_ref().map(|s| s.position_secs).unwrap_or(0.0);
+
             let cmd = match current_state {
                 Some(s) => DiscordCommand::UpdatePresence(Some(s)),
                 None => DiscordCommand::ClearPresence,
@@ -143,15 +206,30 @@ impl DiscordPresence {
     /// Background task managing socket lifecycle and activity updates.
     async fn run_ipc_loop(rx: async_channel::Receiver<DiscordCommand>) {
         let mut client: Option<DiscordIpcClient> = None;
+        let mut last_connect_attempt = SystemTime::UNIX_EPOCH;
 
         while let Ok(cmd) = rx.recv().await {
             match cmd {
                 DiscordCommand::UpdatePresence(Some(state)) => {
-                    // Ensure connected client
+                    // Rate-limit connect retries (5 seconds minimum backoff if client is disconnected)
                     if client.is_none() {
-                        let mut new_client = DiscordIpcClient::new(DISCORD_APP_ID);
-                        if new_client.connect().is_ok() {
-                            client = Some(new_client);
+                        let now = SystemTime::now();
+                        let time_since_last = now
+                            .duration_since(last_connect_attempt)
+                            .unwrap_or_default()
+                            .as_secs();
+                        if time_since_last >= 5 {
+                            last_connect_attempt = now;
+                            let mut new_client = DiscordIpcClient::new(DISCORD_APP_ID);
+                            match new_client.connect() {
+                                Ok(_) => {
+                                    info!("Discord IPC client connected successfully");
+                                    client = Some(new_client);
+                                }
+                                Err(e) => {
+                                    warn!("Failed to connect Discord IPC client: {e}");
+                                }
+                            }
                         }
                     }
 
@@ -170,7 +248,8 @@ impl DiscordPresence {
                                 .duration_since(UNIX_EPOCH)
                                 .map(|d| d.as_millis() as i64)
                                 .unwrap_or(0);
-                            let start_time = now_millis.saturating_sub((state.position_secs * 1000.0) as i64);
+                            let start_time =
+                                now_millis.saturating_sub((state.position_secs * 1000.0) as i64);
 
                             let mut timestamps = Timestamps::new().start(start_time);
                             if let Some(dur) = state.duration_secs {
@@ -180,7 +259,7 @@ impl DiscordPresence {
                             activity = activity.timestamps(timestamps);
                         }
 
-                        // Attempt to resolve cover art URL online via iTunes / Deezer providers
+                        // Attempt to resolve cover art URL online via iTunes / Deezer / Last.fm providers
                         let mut cover_url: Option<String> = None;
                         if !state.artist.is_empty() || !state.album.is_empty() {
                             let query = crate::providers::TrackQuery {
@@ -189,9 +268,18 @@ impl DiscordPresence {
                                 title: state.title.clone(),
                                 duration_secs: state.duration_secs,
                             };
-                            if let Ok(candidates) = crate::providers::search_art(&query) {
-                                if let Some(first) = candidates.first() {
-                                    cover_url = Some(first.thumb_url.clone());
+                            match crate::providers::search_art(&query) {
+                                Ok(candidates) => {
+                                    if let Some(first) = candidates.first() {
+                                        cover_url = Some(first.thumb_url.clone());
+                                        info!(
+                                            "Resolved cover art for '{}' via {}: {}",
+                                            state.title, first.provider, first.thumb_url
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!("Artwork search error for '{}': {e}", state.title);
                                 }
                             }
                         }
@@ -209,16 +297,18 @@ impl DiscordPresence {
                         activity = activity.assets(assets);
 
                         if let Err(e) = cli.set_activity(activity) {
-                            eprintln!("discord rpc set_activity failed: {e}");
-                            // Reconnect on failure next time
+                            error!("Discord RPC set_activity failed: {e}");
                             let _ = cli.close();
                             client = None;
+                        } else {
+                            info!("Discord RPC status updated: '{}' by '{}'", state.title, state.artist);
                         }
                     }
                 }
                 DiscordCommand::UpdatePresence(None) | DiscordCommand::ClearPresence => {
                     if let Some(cli) = client.as_mut() {
                         let _ = cli.clear_activity();
+                        info!("Discord RPC status cleared");
                     }
                 }
             }
@@ -226,6 +316,7 @@ impl DiscordPresence {
 
         if let Some(mut cli) = client {
             let _ = cli.close();
+            info!("Discord IPC loop closed");
         }
     }
 }

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -6,7 +6,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use discord_rich_presence::activity::{Activity, ActivityType, Assets, Timestamps};
+use discord_rich_presence::activity::{Activity, ActivityType, Assets, Button, Timestamps};
 use discord_rich_presence::{DiscordIpc, DiscordIpcClient};
 use gpui::{Context, Entity, Subscription};
 use log::{error, info, warn};
@@ -33,6 +33,7 @@ pub struct DiscordTrackState {
     pub position_secs: f64,
     pub duration_secs: Option<f64>,
     pub is_playing: bool,
+    pub show_button: bool,
 }
 
 impl PartialEq for DiscordTrackState {
@@ -42,8 +43,7 @@ impl PartialEq for DiscordTrackState {
             && self.album == other.album
             && self.duration_secs == other.duration_secs
             && self.is_playing == other.is_playing
-            // Only consider state changed if position jumped/seeked by more than 2 seconds
-            && (self.position_secs - other.position_secs).abs() < 2.0
+            && self.show_button == other.show_button
     }
 }
 
@@ -153,6 +153,7 @@ impl DiscordPresence {
                 position_secs: now.position_secs,
                 duration_secs: now.duration_secs,
                 is_playing,
+                show_button: self.config.show_button,
             }
         });
 
@@ -296,6 +297,19 @@ impl DiscordPresence {
                             .large_text(large_text);
                         activity = activity.assets(assets);
 
+                        // Add clickable "View on Last.fm" button if enabled and artist/title available
+                        let lastfm_url = format!(
+                            "https://www.last.fm/music/{}/_/{}",
+                            url_encode(&state.artist),
+                            url_encode(&state.title)
+                        );
+                        if state.show_button
+                            && (!state.artist.is_empty() || !state.title.is_empty())
+                        {
+                            activity = activity
+                                .buttons(vec![Button::new("View on Last.fm", &lastfm_url)]);
+                        }
+
                         if let Err(e) = cli.set_activity(activity) {
                             error!("Discord RPC set_activity failed: {e}");
                             let _ = cli.close();
@@ -319,4 +333,19 @@ impl DiscordPresence {
             info!("Discord IPC loop closed");
         }
     }
+}
+
+/// Simple percent-encoding for URLs.
+fn url_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for b in input.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            b' ' => out.push('+'),
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
 }

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -37,6 +37,7 @@ pub struct DiscordTrackState {
     pub is_playing: bool,
     pub show_lastfm_button: bool,
     pub show_youtube_button: bool,
+    pub cover_url: Option<String>,
 }
 
 impl PartialEq for DiscordTrackState {
@@ -50,6 +51,7 @@ impl PartialEq for DiscordTrackState {
             && self.is_playing == other.is_playing
             && self.show_lastfm_button == other.show_lastfm_button
             && self.show_youtube_button == other.show_youtube_button
+            && self.cover_url == other.cover_url
     }
 }
 
@@ -60,6 +62,7 @@ pub struct DiscordPresence {
     last_sent_track: Option<DiscordTrackState>,
     last_sent_time: Option<SystemTime>,
     last_sent_position: f64,
+    _art_task: Option<gpui::Task<()>>,
     _player_changed: Subscription,
 }
 
@@ -92,6 +95,7 @@ impl DiscordPresence {
             last_sent_track: None,
             last_sent_time: None,
             last_sent_position: 0.0,
+            _art_task: None,
             _player_changed,
         }
     }
@@ -170,6 +174,7 @@ impl DiscordPresence {
                 is_playing,
                 show_lastfm_button: self.config.show_lastfm_button,
                 show_youtube_button: self.config.show_youtube_button,
+                cover_url: self.last_sent_track.as_ref().and_then(|t| t.cover_url.clone()),
             }
         });
 
@@ -204,6 +209,14 @@ impl DiscordPresence {
         };
 
         if should_update {
+            let track_changed = match (&self.last_sent_track, &current_state) {
+                (Some(prev), Some(curr)) => {
+                    prev.title != curr.title || prev.artist != curr.artist || prev.album != curr.album
+                }
+                (None, Some(_)) => true,
+                _ => false,
+            };
+
             self.last_sent_track = current_state.clone();
             self.last_sent_time = if current_state.is_some() {
                 Some(now_time)
@@ -211,6 +224,33 @@ impl DiscordPresence {
                 None
             };
             self.last_sent_position = current_state.as_ref().map(|s| s.position_secs).unwrap_or(0.0);
+
+            if track_changed {
+                if let Some(curr) = current_state.clone() {
+                    if !curr.artist.is_empty() || !curr.album.is_empty() {
+                        let sender = self.sender.clone();
+                        let mut curr_state = curr;
+                        self._art_task = Some(cx.background_executor().spawn(async move {
+                            let query = crate::providers::TrackQuery {
+                                artist: curr_state.artist.clone(),
+                                album: curr_state.album.clone(),
+                                title: curr_state.title.clone(),
+                                duration_secs: curr_state.duration_secs,
+                            };
+                            if let Ok(candidates) = crate::providers::search_art(&query) {
+                                if let Some(first) = candidates.first() {
+                                    curr_state.cover_url = Some(first.thumb_url.clone());
+                                    info!(
+                                        "Resolved cover art for '{}' via {}: {}",
+                                        curr_state.title, first.provider, first.thumb_url
+                                    );
+                                    let _ = sender.try_send(DiscordCommand::UpdatePresence(Some(curr_state)));
+                                }
+                            }
+                        }));
+                    }
+                }
+            }
 
             let cmd = match current_state {
                 Some(s) => DiscordCommand::UpdatePresence(Some(s)),
@@ -276,32 +316,7 @@ impl DiscordPresence {
                             activity = activity.timestamps(timestamps);
                         }
 
-                        // Attempt to resolve cover art URL online via iTunes / Deezer / Last.fm providers
-                        let mut cover_url: Option<String> = None;
-                        if !state.artist.is_empty() || !state.album.is_empty() {
-                            let query = crate::providers::TrackQuery {
-                                artist: state.artist.clone(),
-                                album: state.album.clone(),
-                                title: state.title.clone(),
-                                duration_secs: state.duration_secs,
-                            };
-                            match crate::providers::search_art(&query) {
-                                Ok(candidates) => {
-                                    if let Some(first) = candidates.first() {
-                                        cover_url = Some(first.thumb_url.clone());
-                                        info!(
-                                            "Resolved cover art for '{}' via {}: {}",
-                                            state.title, first.provider, first.thumb_url
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    warn!("Artwork search error for '{}': {e}", state.title);
-                                }
-                            }
-                        }
-
-                        let image_key = cover_url.as_deref().unwrap_or("app_icon");
+                        let image_key = state.cover_url.as_deref().unwrap_or("app_icon");
                         let format_str = format_quality(&state.codec, state.bitrate_kbps);
 
                         let large_text = match (!state.album.is_empty(), !format_str.is_empty()) {

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -374,19 +374,9 @@ impl DiscordPresence {
     }
 }
 
-/// Simple percent-encoding for URLs.
+/// Standard UTF-8 percent-encoding for URLs.
 fn url_encode(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    for b in input.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(b as char);
-            }
-            b' ' => out.push('+'),
-            _ => out.push_str(&format!("%{:02X}", b)),
-        }
-    }
-    out
+    url::form_urlencoded::byte_serialize(input.as_bytes()).collect()
 }
 
 /// Format audio quality text based on codec and bitrate.

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -297,17 +297,24 @@ impl DiscordPresence {
                             .large_text(large_text);
                         activity = activity.assets(assets);
 
-                        // Add clickable "View on Last.fm" button if enabled and artist/title available
+                        // Add clickable buttons if enabled and artist/title available
                         let lastfm_url = format!(
                             "https://www.last.fm/music/{}/_/{}",
+                            url_encode(&state.artist),
+                            url_encode(&state.title)
+                        );
+                        let youtube_url = format!(
+                            "https://www.youtube.com/results?search_query={}+{}",
                             url_encode(&state.artist),
                             url_encode(&state.title)
                         );
                         if state.show_button
                             && (!state.artist.is_empty() || !state.title.is_empty())
                         {
-                            activity = activity
-                                .buttons(vec![Button::new("View on Last.fm", &lastfm_url)]);
+                            activity = activity.buttons(vec![
+                                Button::new("View on Last.fm", &lastfm_url),
+                                Button::new("Search on YouTube", &youtube_url),
+                            ]);
                         }
 
                         if let Err(e) = cli.set_activity(activity) {

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -117,7 +117,7 @@ impl DiscordPresence {
         let now_playing = player.now_playing();
         let is_playing = player.is_playing();
 
-        let current_state = now_playing.and_then(|now| {
+        let current_state = now_playing.map(|now| {
             let meta = self.library.read(cx).meta_for(&now.path);
             let (title, artist, album) = match meta {
                 Some(m) => (
@@ -146,14 +146,14 @@ impl DiscordPresence {
                 ),
             };
 
-            Some(DiscordTrackState {
+            DiscordTrackState {
                 title,
                 artist,
                 album,
                 position_secs: now.position_secs,
                 duration_secs: now.duration_secs,
                 is_playing,
-            })
+            }
         });
 
         let now_time = SystemTime::now();

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -287,11 +287,29 @@ impl DiscordPresence {
                             };
                             match crate::providers::search_art(&query) {
                                 Ok(candidates) => {
-                                    if let Some(first) = candidates.first() {
-                                        cover_url = Some(first.thumb_url.clone());
+                                    // Prioritize Deezer > Last.fm > iTunes for presence cover art,
+                                    // iTunes sometimes returns cover art for multiple albums 
+                                    // by the creator which makes us use the wrong art?
+                                    let chosen = candidates
+                                        .iter()
+                                        .find(|c| c.provider.eq_ignore_ascii_case("deezer"))
+                                        .or_else(|| {
+                                            candidates
+                                                .iter()
+                                                .find(|c| c.provider.eq_ignore_ascii_case("lastfm"))
+                                        })
+                                        .or_else(|| {
+                                            candidates
+                                                .iter()
+                                                .find(|c| c.provider.eq_ignore_ascii_case("itunes"))
+                                        })
+                                        .or_else(|| candidates.first());
+
+                                    if let Some(c) = chosen {
+                                        cover_url = Some(c.full_url.clone());
                                         info!(
                                             "Resolved cover art for '{}' via {}: {}",
-                                            state.title, first.provider, first.thumb_url
+                                            state.title, c.provider, c.full_url
                                         );
                                     }
                                 }

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -37,7 +37,6 @@ pub struct DiscordTrackState {
     pub is_playing: bool,
     pub show_lastfm_button: bool,
     pub show_youtube_button: bool,
-    pub cover_url: Option<String>,
 }
 
 impl PartialEq for DiscordTrackState {
@@ -51,7 +50,6 @@ impl PartialEq for DiscordTrackState {
             && self.is_playing == other.is_playing
             && self.show_lastfm_button == other.show_lastfm_button
             && self.show_youtube_button == other.show_youtube_button
-            && self.cover_url == other.cover_url
     }
 }
 
@@ -62,7 +60,6 @@ pub struct DiscordPresence {
     last_sent_track: Option<DiscordTrackState>,
     last_sent_time: Option<SystemTime>,
     last_sent_position: f64,
-    _art_task: Option<gpui::Task<()>>,
     _player_changed: Subscription,
 }
 
@@ -95,7 +92,6 @@ impl DiscordPresence {
             last_sent_track: None,
             last_sent_time: None,
             last_sent_position: 0.0,
-            _art_task: None,
             _player_changed,
         }
     }
@@ -174,7 +170,6 @@ impl DiscordPresence {
                 is_playing,
                 show_lastfm_button: self.config.show_lastfm_button,
                 show_youtube_button: self.config.show_youtube_button,
-                cover_url: self.last_sent_track.as_ref().and_then(|t| t.cover_url.clone()),
             }
         });
 
@@ -209,14 +204,6 @@ impl DiscordPresence {
         };
 
         if should_update {
-            let track_changed = match (&self.last_sent_track, &current_state) {
-                (Some(prev), Some(curr)) => {
-                    prev.title != curr.title || prev.artist != curr.artist || prev.album != curr.album
-                }
-                (None, Some(_)) => true,
-                _ => false,
-            };
-
             self.last_sent_track = current_state.clone();
             self.last_sent_time = if current_state.is_some() {
                 Some(now_time)
@@ -224,33 +211,6 @@ impl DiscordPresence {
                 None
             };
             self.last_sent_position = current_state.as_ref().map(|s| s.position_secs).unwrap_or(0.0);
-
-            if track_changed {
-                if let Some(curr) = current_state.clone() {
-                    if !curr.artist.is_empty() || !curr.album.is_empty() {
-                        let sender = self.sender.clone();
-                        let mut curr_state = curr;
-                        self._art_task = Some(cx.background_executor().spawn(async move {
-                            let query = crate::providers::TrackQuery {
-                                artist: curr_state.artist.clone(),
-                                album: curr_state.album.clone(),
-                                title: curr_state.title.clone(),
-                                duration_secs: curr_state.duration_secs,
-                            };
-                            if let Ok(candidates) = crate::providers::search_art(&query) {
-                                if let Some(first) = candidates.first() {
-                                    curr_state.cover_url = Some(first.thumb_url.clone());
-                                    info!(
-                                        "Resolved cover art for '{}' via {}: {}",
-                                        curr_state.title, first.provider, first.thumb_url
-                                    );
-                                    let _ = sender.try_send(DiscordCommand::UpdatePresence(Some(curr_state)));
-                                }
-                            }
-                        }));
-                    }
-                }
-            }
 
             let cmd = match current_state {
                 Some(s) => DiscordCommand::UpdatePresence(Some(s)),
@@ -316,7 +276,32 @@ impl DiscordPresence {
                             activity = activity.timestamps(timestamps);
                         }
 
-                        let image_key = state.cover_url.as_deref().unwrap_or("app_icon");
+                        // Attempt to resolve cover art URL online via iTunes / Deezer / Last.fm providers
+                        let mut cover_url: Option<String> = None;
+                        if !state.artist.is_empty() || !state.album.is_empty() {
+                            let query = crate::providers::TrackQuery {
+                                artist: state.artist.clone(),
+                                album: state.album.clone(),
+                                title: state.title.clone(),
+                                duration_secs: state.duration_secs,
+                            };
+                            match crate::providers::search_art(&query) {
+                                Ok(candidates) => {
+                                    if let Some(first) = candidates.first() {
+                                        cover_url = Some(first.thumb_url.clone());
+                                        info!(
+                                            "Resolved cover art for '{}' via {}: {}",
+                                            state.title, first.provider, first.thumb_url
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!("Artwork search error for '{}': {e}", state.title);
+                                }
+                            }
+                        }
+
+                        let image_key = cover_url.as_deref().unwrap_or("app_icon");
                         let format_str = format_quality(&state.codec, state.bitrate_kbps);
 
                         let large_text = match (!state.album.is_empty(), !format_str.is_empty()) {

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -103,8 +103,15 @@ impl DiscordPresence {
             "Discord RPC settings reloaded: enabled={}, timestamps={}, details={}",
             self.config.enabled, self.config.show_timestamps, self.config.show_details
         );
-        // Force update on next tick
-        self.last_sent_track = None;
+        if !self.config.enabled {
+            self.last_sent_track = None;
+            self.last_sent_time = None;
+            info!("Discord RPC disabled via settings; clearing presence immediately");
+            let _ = self.sender.try_send(DiscordCommand::ClearPresence);
+        } else {
+            // Force update on next tick
+            self.last_sent_track = None;
+        }
     }
 
     /// React to player pump notifications on the main thread.

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -1,0 +1,231 @@
+//! Discord Rich Presence integration: publishes the now-playing track,
+//! playback status (playing/paused), and elapsed timestamps over Discord IPC.
+//!
+//! Socket communication and reconnects run on a background thread to prevent
+//! stalling the main GPUI thread or audio path.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use discord_rich_presence::activity::{Activity, ActivityType, Assets, Timestamps};
+use discord_rich_presence::{DiscordIpc, DiscordIpcClient};
+use gpui::{Context, Entity, Subscription};
+
+use crate::panels::library::Library;
+use crate::player::Player;
+use crate::settings::{DiscordSettings, Settings};
+
+/// Default Discord Client Application ID for rox.
+const DISCORD_APP_ID: &str = "1530943456543772732";
+
+/// Commands sent from the GPUI main thread to the background IPC worker loop.
+pub enum DiscordCommand {
+    UpdatePresence(Option<DiscordTrackState>),
+    ClearPresence,
+}
+
+/// Snapshot of the currently playing track state sent over channel.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DiscordTrackState {
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub position_secs: f64,
+    pub duration_secs: Option<f64>,
+    pub is_playing: bool,
+}
+
+pub struct DiscordPresence {
+    library: Entity<Library>,
+    config: DiscordSettings,
+    sender: async_channel::Sender<DiscordCommand>,
+    last_state: Option<DiscordTrackState>,
+    _player_changed: Subscription,
+}
+
+impl DiscordPresence {
+    pub fn new(
+        player: &Entity<Player>,
+        library: &Entity<Library>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let (tx, rx) = async_channel::bounded::<DiscordCommand>(16);
+
+        // Spawn background task to manage IPC client connection and event loop
+        cx.background_executor()
+            .spawn(async move {
+                Self::run_ipc_loop(rx).await;
+            })
+            .detach();
+
+        // Observe player ticks on GPUI main thread
+        let _player_changed = cx.observe(player, |this: &mut Self, player, cx| {
+            this.tick(&player, cx);
+        });
+
+        Self {
+            library: library.clone(),
+            config: Settings::load().discord,
+            sender: tx,
+            last_state: None,
+            _player_changed,
+        }
+    }
+
+    /// Refresh settings from the active configuration.
+    pub fn reload_config(&mut self) {
+        self.config = Settings::load().discord;
+    }
+
+    /// React to player pump notifications on the main thread.
+    fn tick(&mut self, player: &Entity<Player>, cx: &mut Context<Self>) {
+        if !self.config.enabled {
+            if self.last_state.is_some() {
+                self.last_state = None;
+                let _ = self.sender.try_send(DiscordCommand::ClearPresence);
+            }
+            return;
+        }
+
+        let player = player.read(cx);
+        let now_playing = player.now_playing();
+        let is_playing = player.is_playing();
+
+        let current_state = now_playing.and_then(|now| {
+            let meta = self.library.read(cx).meta_for(&now.path);
+            let (title, artist, album) = match meta {
+                Some(m) => (
+                    if m.title.is_empty() {
+                        now.path
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_else(|| "Unknown Track".into())
+                    } else {
+                        m.title
+                    },
+                    if m.artist.is_empty() {
+                        "Unknown Artist".to_string()
+                    } else {
+                        m.artist
+                    },
+                    m.album,
+                ),
+                None => (
+                    now.path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "Unknown Track".into()),
+                    "Unknown Artist".to_string(),
+                    String::new(),
+                ),
+            };
+
+            Some(DiscordTrackState {
+                title,
+                artist,
+                album,
+                position_secs: now.position_secs,
+                duration_secs: now.duration_secs,
+                is_playing,
+            })
+        });
+
+        // State gating: avoid redundant updates if track state hasn't moved
+        if self.last_state != current_state {
+            self.last_state = current_state.clone();
+            let cmd = match current_state {
+                Some(s) => DiscordCommand::UpdatePresence(Some(s)),
+                None => DiscordCommand::ClearPresence,
+            };
+            let _ = self.sender.try_send(cmd);
+        }
+    }
+
+    /// Background task managing socket lifecycle and activity updates.
+    async fn run_ipc_loop(rx: async_channel::Receiver<DiscordCommand>) {
+        let mut client: Option<DiscordIpcClient> = None;
+
+        while let Ok(cmd) = rx.recv().await {
+            match cmd {
+                DiscordCommand::UpdatePresence(Some(state)) => {
+                    // Ensure connected client
+                    if client.is_none() {
+                        let mut new_client = DiscordIpcClient::new(DISCORD_APP_ID);
+                        if new_client.connect().is_ok() {
+                            client = Some(new_client);
+                        }
+                    }
+
+                    if let Some(cli) = client.as_mut() {
+                        let details = state.title.clone();
+                        let state_str = format!("by {}", state.artist);
+
+                        let mut activity = Activity::new()
+                            .activity_type(ActivityType::Listening)
+                            .details(&details)
+                            .state(&state_str);
+
+                        // Add timestamp if enabled and playing
+                        if state.is_playing {
+                            let now_millis = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .map(|d| d.as_millis() as i64)
+                                .unwrap_or(0);
+                            let start_time = now_millis.saturating_sub((state.position_secs * 1000.0) as i64);
+
+                            let mut timestamps = Timestamps::new().start(start_time);
+                            if let Some(dur) = state.duration_secs {
+                                let end_time = start_time + ((dur * 1000.0) as i64);
+                                timestamps = timestamps.end(end_time);
+                            }
+                            activity = activity.timestamps(timestamps);
+                        }
+
+                        // Attempt to resolve cover art URL online via iTunes / Deezer providers
+                        let mut cover_url: Option<String> = None;
+                        if !state.artist.is_empty() || !state.album.is_empty() {
+                            let query = crate::providers::TrackQuery {
+                                artist: state.artist.clone(),
+                                album: state.album.clone(),
+                                title: state.title.clone(),
+                                duration_secs: state.duration_secs,
+                            };
+                            if let Ok(candidates) = crate::providers::search_art(&query) {
+                                if let Some(first) = candidates.first() {
+                                    cover_url = Some(first.thumb_url.clone());
+                                }
+                            }
+                        }
+
+                        let image_key = cover_url.as_deref().unwrap_or("app_icon");
+                        let large_text = if state.album.is_empty() {
+                            state.title.as_str()
+                        } else {
+                            state.album.as_str()
+                        };
+
+                        let assets = Assets::new()
+                            .large_image(image_key)
+                            .large_text(large_text);
+                        activity = activity.assets(assets);
+
+                        if let Err(e) = cli.set_activity(activity) {
+                            log::warn!("discord rpc set_activity failed: {e}");
+                            // Reconnect on failure next time
+                            let _ = cli.close();
+                            client = None;
+                        }
+                    }
+                }
+                DiscordCommand::UpdatePresence(None) | DiscordCommand::ClearPresence => {
+                    if let Some(cli) = client.as_mut() {
+                        let _ = cli.clear_activity();
+                    }
+                }
+            }
+        }
+
+        if let Some(mut cli) = client {
+            let _ = cli.close();
+        }
+    }
+}

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -15,8 +15,8 @@ use crate::panels::library::Library;
 use crate::player::Player;
 use crate::settings::{DiscordSettings, Settings};
 
-/// Discord Client Application ID for rox.
-const DISCORD_APP_ID: &str = "1530943456543772732";
+/// Discord Client Application ID for rox, injected at compile time via DISCORD_APP_ID env var.
+const DISCORD_APP_ID: Option<&'static str> = option_env!("DISCORD_APP_ID");
 
 /// Commands sent from the GPUI main thread to the background IPC worker loop.
 pub enum DiscordCommand {
@@ -229,6 +229,9 @@ impl DiscordPresence {
 
     /// Background task managing socket lifecycle and activity updates.
     async fn run_ipc_loop(rx: async_channel::Receiver<DiscordCommand>) {
+        let Some(app_id) = DISCORD_APP_ID else {
+            return;
+        };
         let mut client: Option<DiscordIpcClient> = None;
         let mut last_connect_attempt = SystemTime::UNIX_EPOCH;
 
@@ -244,7 +247,7 @@ impl DiscordPresence {
                             .as_secs();
                         if time_since_last >= 5 {
                             last_connect_attempt = now;
-                            let mut new_client = DiscordIpcClient::new(DISCORD_APP_ID);
+                            let mut new_client = DiscordIpcClient::new(app_id);
                             match new_client.connect() {
                                 Ok(_) => {
                                     info!("Discord IPC client connected successfully");

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -15,7 +15,7 @@ use crate::panels::library::Library;
 use crate::player::Player;
 use crate::settings::{DiscordSettings, Settings};
 
-/// Default Discord Client Application ID for rox.
+/// Discord Client Application ID for rox.
 const DISCORD_APP_ID: &str = "1530943456543772732";
 
 /// Commands sent from the GPUI main thread to the background IPC worker loop.
@@ -308,9 +308,17 @@ impl DiscordPresence {
                             (false, false) => state.title.clone(),
                         };
 
+                        let (small_key, small_text) = if state.is_playing {
+                            ("play", "Playing")
+                        } else {
+                            ("pause", "Paused")
+                        };
+
                         let assets = Assets::new()
                             .large_image(image_key)
-                            .large_text(&large_text);
+                            .large_text(&large_text)
+                            .small_image(small_key)
+                            .small_text(small_text);
                         activity = activity.assets(assets);
 
                         // Add clickable buttons if enabled and artist/title available

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -30,6 +30,8 @@ pub struct DiscordTrackState {
     pub title: String,
     pub artist: String,
     pub album: String,
+    pub codec: String,
+    pub bitrate_kbps: u16,
     pub position_secs: f64,
     pub duration_secs: Option<f64>,
     pub is_playing: bool,
@@ -41,6 +43,8 @@ impl PartialEq for DiscordTrackState {
         self.title == other.title
             && self.artist == other.artist
             && self.album == other.album
+            && self.codec == other.codec
+            && self.bitrate_kbps == other.bitrate_kbps
             && self.duration_secs == other.duration_secs
             && self.is_playing == other.is_playing
             && self.show_button == other.show_button
@@ -119,7 +123,7 @@ impl DiscordPresence {
 
         let current_state = now_playing.map(|now| {
             let meta = self.library.read(cx).meta_for(&now.path);
-            let (title, artist, album) = match meta {
+            let (title, artist, album, codec, bitrate_kbps) = match meta {
                 Some(m) => (
                     if m.title.is_empty() {
                         now.path
@@ -135,6 +139,8 @@ impl DiscordPresence {
                         m.artist
                     },
                     m.album,
+                    m.codec,
+                    m.bitrate_kbps,
                 ),
                 None => (
                     now.path
@@ -143,6 +149,11 @@ impl DiscordPresence {
                         .unwrap_or_else(|| "Unknown Track".into()),
                     "Unknown Artist".to_string(),
                     String::new(),
+                    now.path
+                        .extension()
+                        .map(|e| e.to_string_lossy().to_string())
+                        .unwrap_or_default(),
+                    0,
                 ),
             };
 
@@ -150,6 +161,8 @@ impl DiscordPresence {
                 title,
                 artist,
                 album,
+                codec,
+                bitrate_kbps,
                 position_secs: now.position_secs,
                 duration_secs: now.duration_secs,
                 is_playing,
@@ -286,15 +299,18 @@ impl DiscordPresence {
                         }
 
                         let image_key = cover_url.as_deref().unwrap_or("app_icon");
-                        let large_text = if state.album.is_empty() {
-                            state.title.as_str()
-                        } else {
-                            state.album.as_str()
+                        let format_str = format_quality(&state.codec, state.bitrate_kbps);
+
+                        let large_text = match (!state.album.is_empty(), !format_str.is_empty()) {
+                            (true, true) => format!("{} • {}", state.album, format_str),
+                            (true, false) => state.album.clone(),
+                            (false, true) => format_str,
+                            (false, false) => state.title.clone(),
                         };
 
                         let assets = Assets::new()
                             .large_image(image_key)
-                            .large_text(large_text);
+                            .large_text(&large_text);
                         activity = activity.assets(assets);
 
                         // Add clickable buttons if enabled and artist/title available
@@ -355,4 +371,31 @@ fn url_encode(input: &str) -> String {
         }
     }
     out
+}
+
+/// Format audio quality text based on codec and bitrate.
+fn format_quality(codec: &str, bitrate_kbps: u16) -> String {
+    if codec.is_empty() {
+        return String::new();
+    }
+    let codec_upper = codec.to_uppercase();
+    match codec_upper.as_str() {
+        "FLAC" | "ALAC" | "WAV" | "AIFF" | "PCM" => {
+            format!("{codec_upper} Lossless")
+        }
+        "MP3" | "AAC" | "OGG" | "OPUS" | "M4A" | "VORBIS" => {
+            if bitrate_kbps > 0 {
+                format!("{codec_upper} {bitrate_kbps} kbps")
+            } else {
+                format!("{codec_upper} VBR")
+            }
+        }
+        _ => {
+            if bitrate_kbps > 0 {
+                format!("{codec_upper} {bitrate_kbps} kbps")
+            } else {
+                codec_upper
+            }
+        }
+    }
 }

--- a/crates/rox/src/integrations/discord.rs
+++ b/crates/rox/src/integrations/discord.rs
@@ -209,7 +209,7 @@ impl DiscordPresence {
                         activity = activity.assets(assets);
 
                         if let Err(e) = cli.set_activity(activity) {
-                            log::warn!("discord rpc set_activity failed: {e}");
+                            eprintln!("discord rpc set_activity failed: {e}");
                             // Reconnect on failure next time
                             let _ = cli.close();
                             client = None;

--- a/crates/rox/src/integrations/mod.rs
+++ b/crates/rox/src/integrations/mod.rs
@@ -2,6 +2,7 @@
 //! tray for windowless residency, and the filesystem watcher for the
 //! library roots.
 
+pub mod discord;
 pub mod library_watch;
 pub mod media_controls;
 pub mod tray;

--- a/crates/rox/src/main.rs
+++ b/crates/rox/src/main.rs
@@ -270,6 +270,7 @@ fn main() {
         providers::set_metadata_online(settings.providers.musicbrainz);
         providers::set_itunes_online(settings.providers.itunes);
         providers::set_deezer_online(settings.providers.deezer);
+        providers::set_lastfm_art_online(settings.providers.lastfm_art);
         providers::set_artist_online(settings.providers.artist);
         // The daily update check, off the UI thread; the toggle and the
         // one-day cache both gate it, so most launches do nothing here.

--- a/crates/rox/src/panel.rs
+++ b/crates/rox/src/panel.rs
@@ -29,6 +29,7 @@ use crate::backdrop::{NowPlayingArt, WindowBackdrop};
 use crate::design::palette::PanelTheme;
 use crate::design::{palette, tokens};
 use crate::history::History;
+use crate::integrations::discord::DiscordPresence;
 use crate::lastfm::Scrobbler;
 use crate::panels::library::Library;
 use crate::player::{fmt_time, Player};
@@ -66,6 +67,8 @@ pub struct AppState {
     /// The listen recorder riding the scrobbler's listen signal; history
     /// views subscribe to it for the refresh when an event lands.
     pub history: Entity<History>,
+    /// Discord Rich Presence publisher watching the player.
+    pub discord: Entity<DiscordPresence>,
 }
 
 /// Every tab panel that has hosted one of our panels, reported from each

--- a/crates/rox/src/providers/lastfm.rs
+++ b/crates/rox/src/providers/lastfm.rs
@@ -238,15 +238,27 @@ impl ArtProvider for LastfmArt {
             return Ok(Vec::new());
         }
 
+        let full = full_size_url(&best_url);
         Ok(vec![ArtCandidate {
             provider: self.name(),
             album: title,
-            thumb_url: best_url.clone(),
-            full_url: best_url,
-            width: 300,
-            height: 300,
+            thumb_url: best_url,
+            full_url: full,
+            width: 1000,
+            height: 1000,
         }])
     }
+}
+
+/// Rewrite Last.fm CDN size path segments (e.g. `/300x300/` or `/174s/`) to
+/// full resolution (`/ar0/`).
+fn full_size_url(url: &str) -> String {
+    for segment in &["/300x300/", "/174s/", "/64s/", "/34s/", "/mega/"] {
+        if url.contains(segment) {
+            return url.replace(segment, "/ar0/");
+        }
+    }
+    url.to_string()
 }
 
 #[cfg(test)]

--- a/crates/rox/src/providers/lastfm.rs
+++ b/crates/rox/src/providers/lastfm.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::settings::Settings;
 
-use super::{agent, net_reason, string};
+use super::{agent, net_reason, string, ArtCandidate, ArtProvider, TrackQuery};
 
 const API: &str = "https://ws.audioscrobbler.com/2.0/";
 
@@ -171,6 +171,82 @@ fn strip_wiki(html: &str) -> String {
         blank = false;
     }
     out
+}
+
+pub struct LastfmArt;
+
+impl ArtProvider for LastfmArt {
+    fn name(&self) -> &'static str {
+        "lastfm"
+    }
+
+    fn search(&self, query: &TrackQuery) -> Result<Vec<ArtCandidate>, String> {
+        let key = api_key();
+        if key.is_empty() || query.artist.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        let album_name = if query.album.is_empty() {
+            &query.title
+        } else {
+            &query.album
+        };
+        if album_name.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let request = agent()
+            .get(API)
+            .query("method", "album.getinfo")
+            .query("artist", query.artist.trim())
+            .query("album", album_name.trim())
+            .query("autocorrect", "1")
+            .query("api_key", &key)
+            .query("format", "json");
+
+        let text = match request.call() {
+            Ok(response) => response.into_string().map_err(|e| e.to_string())?,
+            Err(ureq::Error::Status(_, response)) => {
+                response.into_string().map_err(|e| e.to_string())?
+            }
+            Err(e) => return Err(e.to_string()),
+        };
+
+        let body: serde_json::Value = serde_json::from_str(&text).map_err(|e| e.to_string())?;
+        if body.get("error").is_some() {
+            return Ok(Vec::new());
+        }
+
+        let Some(album) = body.get("album") else {
+            return Ok(Vec::new());
+        };
+
+        let title = string(album.get("name"));
+        let images = album.get("image").and_then(|i| i.as_array());
+
+        let mut best_url = String::new();
+        if let Some(imgs) = images {
+            for img in imgs.iter().rev() {
+                let url = string(img.get("#text"));
+                if !url.is_empty() {
+                    best_url = url;
+                    break;
+                }
+            }
+        }
+
+        if best_url.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        Ok(vec![ArtCandidate {
+            provider: self.name(),
+            album: title,
+            thumb_url: best_url.clone(),
+            full_url: best_url,
+            width: 300,
+            height: 300,
+        }])
+    }
 }
 
 #[cfg(test)]

--- a/crates/rox/src/providers/mod.rs
+++ b/crates/rox/src/providers/mod.rs
@@ -90,11 +90,12 @@ pub fn set_metadata_online(on: bool) {
     METADATA_ONLINE.store(on, Ordering::Relaxed);
 }
 
-/// Whether each cover-art service is enabled. Two providers rather than
+/// Whether each cover-art service is enabled. Three providers rather than
 /// one domain flag, so a user can lean on whichever service covers their
 /// library better. Seeded at startup, flipped by the Providers page.
 static ITUNES_ONLINE: AtomicBool = AtomicBool::new(true);
 static DEEZER_ONLINE: AtomicBool = AtomicBool::new(true);
+static LASTFM_ART_ONLINE: AtomicBool = AtomicBool::new(true);
 
 pub fn itunes_online() -> bool {
     ITUNES_ONLINE.load(Ordering::Relaxed)
@@ -112,10 +113,18 @@ pub fn set_deezer_online(on: bool) {
     DEEZER_ONLINE.store(on, Ordering::Relaxed);
 }
 
+pub fn lastfm_art_online() -> bool {
+    LASTFM_ART_ONLINE.load(Ordering::Relaxed)
+}
+
+pub fn set_lastfm_art_online(on: bool) {
+    LASTFM_ART_ONLINE.store(on, Ordering::Relaxed);
+}
+
 /// Whether any cover-art service is on, the gate for offering the search
 /// at all.
 pub fn art_online() -> bool {
-    itunes_online() || deezer_online()
+    itunes_online() || deezer_online() || lastfm_art_online()
 }
 
 /// Whether the artist lookup is enabled - the biography panel's domain:
@@ -380,10 +389,17 @@ pub trait ArtProvider {
 /// rather than failing the lot; only when all fail and nothing came back
 /// does the error surface.
 pub fn search_art(query: &TrackQuery) -> Result<Vec<ArtCandidate>, String> {
-    let (itunes, deezer) = (itunes_online(), deezer_online());
+    let (itunes, deezer, lastfm_art) = (
+        itunes_online(),
+        deezer_online(),
+        lastfm_art_online(),
+    );
     // Which services are on is part of the answer, so it rides the key: a
     // toggle since the last search is a different result, not a stale hit.
-    let key = format!("{}\u{1f}{itunes}\u{1f}{deezer}", query_key(query));
+    let key = format!(
+        "{}\u{1f}{itunes}\u{1f}{deezer}\u{1f}{lastfm_art}",
+        query_key(query)
+    );
     static CACHE: OnceLock<SessionCache<Vec<ArtCandidate>>> = OnceLock::new();
     let cache = CACHE.get_or_init(Default::default);
     cache.get_or_compute(key, || {
@@ -394,7 +410,9 @@ pub fn search_art(query: &TrackQuery) -> Result<Vec<ArtCandidate>, String> {
         if deezer {
             providers.push(&deezer::Deezer);
         }
-        providers.push(&lastfm::LastfmArt);
+        if lastfm_art {
+            providers.push(&lastfm::LastfmArt);
+        }
         let mut found = collect_candidates(providers.iter().map(|p| p.search(query)))?;
         found.sort_by_key(|b| std::cmp::Reverse(b.width * b.height));
         Ok(found)

--- a/crates/rox/src/providers/mod.rs
+++ b/crates/rox/src/providers/mod.rs
@@ -394,6 +394,7 @@ pub fn search_art(query: &TrackQuery) -> Result<Vec<ArtCandidate>, String> {
         if deezer {
             providers.push(&deezer::Deezer);
         }
+        providers.push(&lastfm::LastfmArt);
         let mut found = collect_candidates(providers.iter().map(|p| p.search(query)))?;
         found.sort_by_key(|b| std::cmp::Reverse(b.width * b.height));
         Ok(found)

--- a/crates/rox/src/settings.rs
+++ b/crates/rox/src/settings.rs
@@ -279,6 +279,8 @@ pub struct Settings {
     /// The online enrichment providers and their knobs (ADR 14), the
     /// settings window's Providers page.
     pub providers: Providers,
+    /// Discord Rich Presence options (enable toggle, timestamps, details).
+    pub discord: DiscordSettings,
     /// The quick-play modal's appearance knobs, edited from its own config
     /// panel.
     pub quick_play: QuickPlayConfig,
@@ -719,6 +721,28 @@ impl Default for Providers {
     }
 }
 
+/// Discord Rich Presence settings: enable toggle and metadata options.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiscordSettings {
+    /// Whether Discord Rich Presence is enabled.
+    pub enabled: bool,
+    /// Whether track elapsed time is shown in Discord.
+    pub show_timestamps: bool,
+    /// Whether track title/artist details are shown.
+    pub show_details: bool,
+}
+
+impl Default for DiscordSettings {
+    fn default() -> Self {
+        DiscordSettings {
+            enabled: true,
+            show_timestamps: true,
+            show_details: true,
+        }
+    }
+}
+
 /// A dock layout the user saved as a named preset: a full dock dump under
 /// a name. The dump stays raw JSON like [`Settings::layout`] so the file
 /// survives layout-schema moves; the workspace validates it on apply.
@@ -1047,6 +1071,7 @@ impl Default for Settings {
             last_queue: None,
             lastfm: Lastfm::default(),
             providers: Providers::default(),
+            discord: DiscordSettings::default(),
             quick_play: QuickPlayConfig::default(),
             rating_style: RatingStyle::default(),
             check_updates: true,

--- a/crates/rox/src/settings.rs
+++ b/crates/rox/src/settings.rs
@@ -731,6 +731,8 @@ pub struct DiscordSettings {
     pub show_timestamps: bool,
     /// Whether track title/artist details are shown.
     pub show_details: bool,
+    /// Whether "View on Last.fm" button is shown.
+    pub show_button: bool,
 }
 
 impl Default for DiscordSettings {
@@ -739,6 +741,7 @@ impl Default for DiscordSettings {
             enabled: true,
             show_timestamps: true,
             show_details: true,
+            show_button: true,
         }
     }
 }

--- a/crates/rox/src/settings.rs
+++ b/crates/rox/src/settings.rs
@@ -732,7 +732,6 @@ pub struct DiscordSettings {
     /// Whether track title/artist details are shown.
     pub show_details: bool,
     /// Whether "View on Last.fm" button is shown.
-    #[serde(alias = "show_button")]
     pub show_lastfm_button: bool,
     /// Whether "Search on YouTube" button is shown.
     pub show_youtube_button: bool,
@@ -741,7 +740,7 @@ pub struct DiscordSettings {
 impl Default for DiscordSettings {
     fn default() -> Self {
         DiscordSettings {
-            enabled: true,
+            enabled: false,
             show_timestamps: true,
             show_details: true,
             show_lastfm_button: true,

--- a/crates/rox/src/settings.rs
+++ b/crates/rox/src/settings.rs
@@ -703,6 +703,8 @@ pub struct Providers {
     pub itunes: bool,
     /// Search Deezer for cover art when the cover lookup asks.
     pub deezer: bool,
+    /// Search Last.fm for cover art when the cover lookup asks.
+    pub lastfm_art: bool,
     /// Fetch artist biographies from last.fm, a Deezer portrait along,
     /// when the biography panel asks.
     pub artist: bool,
@@ -716,6 +718,7 @@ impl Default for Providers {
             musicbrainz: true,
             itunes: true,
             deezer: true,
+            lastfm_art: true,
             artist: true,
         }
     }

--- a/crates/rox/src/settings.rs
+++ b/crates/rox/src/settings.rs
@@ -730,10 +730,6 @@ impl Default for Providers {
 pub struct DiscordSettings {
     /// Whether Discord Rich Presence is enabled.
     pub enabled: bool,
-    /// Whether track elapsed time is shown in Discord.
-    pub show_timestamps: bool,
-    /// Whether track title/artist details are shown.
-    pub show_details: bool,
     /// Whether "View on Last.fm" button is shown.
     pub show_lastfm_button: bool,
     /// Whether "Search on YouTube" button is shown.
@@ -744,8 +740,6 @@ impl Default for DiscordSettings {
     fn default() -> Self {
         DiscordSettings {
             enabled: false,
-            show_timestamps: true,
-            show_details: true,
             show_lastfm_button: true,
             show_youtube_button: true,
         }

--- a/crates/rox/src/settings.rs
+++ b/crates/rox/src/settings.rs
@@ -732,7 +732,10 @@ pub struct DiscordSettings {
     /// Whether track title/artist details are shown.
     pub show_details: bool,
     /// Whether "View on Last.fm" button is shown.
-    pub show_button: bool,
+    #[serde(alias = "show_button")]
+    pub show_lastfm_button: bool,
+    /// Whether "Search on YouTube" button is shown.
+    pub show_youtube_button: bool,
 }
 
 impl Default for DiscordSettings {
@@ -741,7 +744,8 @@ impl Default for DiscordSettings {
             enabled: true,
             show_timestamps: true,
             show_details: true,
-            show_button: true,
+            show_lastfm_button: true,
+            show_youtube_button: true,
         }
     }
 }

--- a/crates/rox/src/settings/ui.rs
+++ b/crates/rox/src/settings/ui.rs
@@ -48,7 +48,7 @@ pub fn checkbox(on: bool) -> Div {
 }
 
 /// The sidebar's width, room for a page name and no more.
-pub const SIDEBAR_W: Pixels = px(140.);
+pub const SIDEBAR_W: Pixels = px(160.);
 
 /// The scalar sliders' strip width; the percent readout rides beside it.
 pub const SLIDER_W: Pixels = px(140.);
@@ -115,7 +115,7 @@ pub fn nav_item<P: 'static>(
             MouseButton::Left,
             cx.listener(move |this, _, _, cx| on_pick(this, cx)),
         )
-        .child(svg().path(icon).size(px(14.)).text_color(palette::text()))
+        .child(svg().path(icon).size(px(14.)).flex_none().text_color(palette::text()))
         .child(label)
 }
 
@@ -184,7 +184,7 @@ pub fn small_button(
                     .on_mouse_down(MouseButton::Left, on_click)
             }
         })
-        .child(svg().path(icon).size(px(12.)).text_color(palette::text()))
+        .child(svg().path(icon).size(px(12.)).flex_none().text_color(palette::text()))
         .child(label.into())
 }
 
@@ -208,7 +208,7 @@ pub fn icon_button(
                     .on_mouse_down(MouseButton::Left, on_click)
             }
         })
-        .child(svg().path(icon).size(px(14.)).text_color(palette::text()))
+        .child(svg().path(icon).size(px(14.)).flex_none().text_color(palette::text()))
 }
 
 /// One scalar's slider: the shared slider chrome over a scrub strip,

--- a/crates/rox/src/settings/window.rs
+++ b/crates/rox/src/settings/window.rs
@@ -244,7 +244,8 @@ struct SettingsWindow {
     discord_enabled: bool,
     discord_show_timestamps: bool,
     discord_show_details: bool,
-    discord_show_button: bool,
+    discord_show_lastfm_button: bool,
+    discord_show_youtube_button: bool,
     /// The api credential inputs; edits mirror into the scrobbler per
     /// keystroke, the pickers' cadence.
     lastfm_key: Entity<InputState>,
@@ -452,7 +453,8 @@ impl SettingsWindow {
             discord_enabled: settings.discord.enabled,
             discord_show_timestamps: settings.discord.show_timestamps,
             discord_show_details: settings.discord.show_details,
-            discord_show_button: settings.discord.show_button,
+            discord_show_lastfm_button: settings.discord.show_lastfm_button,
+            discord_show_youtube_button: settings.discord.show_youtube_button,
             lastfm_key,
             lastfm_secret,
             threshold_scrub: ScrubState::default(),
@@ -619,9 +621,16 @@ impl SettingsWindow {
         cx.notify();
     }
 
-    fn set_discord_show_button(&mut self, on: bool, cx: &mut Context<Self>) {
-        self.discord_show_button = on;
-        Settings::update(move |s| s.discord.show_button = on);
+    fn set_discord_show_lastfm_button(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.discord_show_lastfm_button = on;
+        Settings::update(move |s| s.discord.show_lastfm_button = on);
+        self.discord.update(cx, |d, _| d.reload_config());
+        cx.notify();
+    }
+
+    fn set_discord_show_youtube_button(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.discord_show_youtube_button = on;
+        Settings::update(move |s| s.discord.show_youtube_button = on);
         self.discord.update(cx, |d, _| d.reload_config());
         cx.notify();
     }
@@ -1509,8 +1518,17 @@ impl SettingsWindow {
                         "Show Last.fm Button",
                         Some("Include a clickable 'View on Last.fm' button in Discord status"),
                         panel::toggle(
-                            self.discord_show_button,
-                            Self::set_discord_show_button,
+                            self.discord_show_lastfm_button,
+                            Self::set_discord_show_lastfm_button,
+                            cx,
+                        ),
+                    ))
+                    .child(panel::setting_row(
+                        "Show YouTube Button",
+                        Some("Include a clickable 'Search on YouTube' button in Discord status"),
+                        panel::toggle(
+                            self.discord_show_youtube_button,
+                            Self::set_discord_show_youtube_button,
                             cx,
                         ),
                     )),

--- a/crates/rox/src/settings/window.rs
+++ b/crates/rox/src/settings/window.rs
@@ -236,7 +236,7 @@ struct SettingsWindow {
     /// The shared thumbnail service, whose durable store the storage
     /// page sizes and clears.
     thumbs: Entity<Thumbs>,
-    /// The workspace's scrobbler, the Scrobbling page's subject: the api
+    /// The workspace's scrobbler, the Integration page's subject: the api
     /// credential edits, the connect flow, and the knobs all go through
     /// it, and it persists them.
     scrobbler: Entity<Scrobbler>,

--- a/crates/rox/src/settings/window.rs
+++ b/crates/rox/src/settings/window.rs
@@ -132,7 +132,7 @@ const PAGES: &[(Page, &str, &str)] = &[
     (Page::Workspace, "Workspace", icons::APP_WINDOW),
     (Page::Library, "Library", icons::LIST_MUSIC),
     (Page::Providers, "Providers", icons::DOWNLOAD),
-    (Page::Scrobbling, "Scrobbling", icons::RADIO),
+    (Page::Scrobbling, "Integrations", icons::RADIO),
     (Page::Storage, "Storage", icons::DATABASE),
 ];
 

--- a/crates/rox/src/settings/window.rs
+++ b/crates/rox/src/settings/window.rs
@@ -242,8 +242,6 @@ struct SettingsWindow {
     scrobbler: Entity<Scrobbler>,
     discord: Entity<DiscordPresence>,
     discord_enabled: bool,
-    discord_show_timestamps: bool,
-    discord_show_details: bool,
     discord_show_lastfm_button: bool,
     discord_show_youtube_button: bool,
     /// The api credential inputs; edits mirror into the scrobbler per
@@ -451,8 +449,6 @@ impl SettingsWindow {
             scrobbler,
             discord: state.discord.clone(),
             discord_enabled: settings.discord.enabled,
-            discord_show_timestamps: settings.discord.show_timestamps,
-            discord_show_details: settings.discord.show_details,
             discord_show_lastfm_button: settings.discord.show_lastfm_button,
             discord_show_youtube_button: settings.discord.show_youtube_button,
             lastfm_key,
@@ -603,35 +599,21 @@ impl SettingsWindow {
     fn set_discord_enabled(&mut self, on: bool, cx: &mut Context<Self>) {
         self.discord_enabled = on;
         Settings::update(move |s| s.discord.enabled = on);
-        self.discord.update(cx, |d, _| d.reload_config());
-        cx.notify();
-    }
-
-    fn set_discord_show_timestamps(&mut self, on: bool, cx: &mut Context<Self>) {
-        self.discord_show_timestamps = on;
-        Settings::update(move |s| s.discord.show_timestamps = on);
-        self.discord.update(cx, |d, _| d.reload_config());
-        cx.notify();
-    }
-
-    fn set_discord_show_details(&mut self, on: bool, cx: &mut Context<Self>) {
-        self.discord_show_details = on;
-        Settings::update(move |s| s.discord.show_details = on);
-        self.discord.update(cx, |d, _| d.reload_config());
+        self.discord.update(cx, |d, cx| d.reload_config(cx));
         cx.notify();
     }
 
     fn set_discord_show_lastfm_button(&mut self, on: bool, cx: &mut Context<Self>) {
         self.discord_show_lastfm_button = on;
         Settings::update(move |s| s.discord.show_lastfm_button = on);
-        self.discord.update(cx, |d, _| d.reload_config());
+        self.discord.update(cx, |d, cx| d.reload_config(cx));
         cx.notify();
     }
 
     fn set_discord_show_youtube_button(&mut self, on: bool, cx: &mut Context<Self>) {
         self.discord_show_youtube_button = on;
         Settings::update(move |s| s.discord.show_youtube_button = on);
-        self.discord.update(cx, |d, _| d.reload_config());
+        self.discord.update(cx, |d, cx| d.reload_config(cx));
         cx.notify();
     }
 
@@ -1495,24 +1477,6 @@ impl SettingsWindow {
                         "Enable Rich Presence",
                         Some("Show rox activity on Discord when playing music"),
                         panel::toggle(self.discord_enabled, Self::set_discord_enabled, cx),
-                    ))
-                    .child(panel::setting_row(
-                        "Show Song Progress",
-                        Some("Display live progress bar and elapsed/duration timestamps"),
-                        panel::toggle(
-                            self.discord_show_timestamps,
-                            Self::set_discord_show_timestamps,
-                            cx,
-                        ),
-                    ))
-                    .child(panel::setting_row(
-                        "Show Song & Artist Details",
-                        Some("Include track title, artist, and album name in Discord activity"),
-                        panel::toggle(
-                            self.discord_show_details,
-                            Self::set_discord_show_details,
-                            cx,
-                        ),
                     ))
                     .child(panel::setting_row(
                         "Show Last.fm Button",

--- a/crates/rox/src/settings/window.rs
+++ b/crates/rox/src/settings/window.rs
@@ -244,6 +244,7 @@ struct SettingsWindow {
     discord_enabled: bool,
     discord_show_timestamps: bool,
     discord_show_details: bool,
+    discord_show_button: bool,
     /// The api credential inputs; edits mirror into the scrobbler per
     /// keystroke, the pickers' cadence.
     lastfm_key: Entity<InputState>,
@@ -451,6 +452,7 @@ impl SettingsWindow {
             discord_enabled: settings.discord.enabled,
             discord_show_timestamps: settings.discord.show_timestamps,
             discord_show_details: settings.discord.show_details,
+            discord_show_button: settings.discord.show_button,
             lastfm_key,
             lastfm_secret,
             threshold_scrub: ScrubState::default(),
@@ -613,6 +615,13 @@ impl SettingsWindow {
     fn set_discord_show_details(&mut self, on: bool, cx: &mut Context<Self>) {
         self.discord_show_details = on;
         Settings::update(move |s| s.discord.show_details = on);
+        self.discord.update(cx, |d, _| d.reload_config());
+        cx.notify();
+    }
+
+    fn set_discord_show_button(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.discord_show_button = on;
+        Settings::update(move |s| s.discord.show_button = on);
         self.discord.update(cx, |d, _| d.reload_config());
         cx.notify();
     }
@@ -1494,6 +1503,15 @@ impl SettingsWindow {
                         panel::toggle(
                             self.discord_show_details,
                             Self::set_discord_show_details,
+                            cx,
+                        ),
+                    ))
+                    .child(panel::setting_row(
+                        "Show Last.fm Button",
+                        Some("Include a clickable 'View on Last.fm' button in Discord status"),
+                        panel::toggle(
+                            self.discord_show_button,
+                            Self::set_discord_show_button,
                             cx,
                         ),
                     )),

--- a/crates/rox/src/settings/window.rs
+++ b/crates/rox/src/settings/window.rs
@@ -1583,6 +1583,15 @@ impl SettingsWindow {
         cx.notify();
     }
 
+    /// The Last.fm cover-art toggle, Deezer's twin.
+    fn set_lastfm_art(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.providers.lastfm_art = on;
+        providers::set_lastfm_art_online(on);
+        let config = self.providers.clone();
+        Settings::update(move |s| s.providers = config);
+        cx.notify();
+    }
+
     /// The artist-lookup toggle: through the live static, so the
     /// biography panel's fetches follow it.
     fn set_artist(&mut self, on: bool, cx: &mut Context<Self>) {
@@ -1664,6 +1673,11 @@ impl SettingsWindow {
                     "Deezer",
                     Some("Search Deezer for cover art, up to 1000 pixels"),
                     panel::toggle(self.providers.deezer, Self::set_deezer, cx),
+                ))
+                .child(panel::setting_row(
+                    "Last.fm",
+                    Some("Search Last.fm for cover art"),
+                    panel::toggle(self.providers.lastfm_art, Self::set_lastfm_art, cx),
                 )),
         ))
         .child(section(

--- a/crates/rox/src/settings/window.rs
+++ b/crates/rox/src/settings/window.rs
@@ -122,7 +122,7 @@ enum Page {
     Workspace,
     Library,
     Providers,
-    Scrobbling,
+    Integrations,
     Storage,
 }
 
@@ -132,7 +132,7 @@ const PAGES: &[(Page, &str, &str)] = &[
     (Page::Workspace, "Workspace", icons::APP_WINDOW),
     (Page::Library, "Library", icons::LIST_MUSIC),
     (Page::Providers, "Providers", icons::DOWNLOAD),
-    (Page::Scrobbling, "Integrations", icons::RADIO),
+    (Page::Integrations, "Integrations", icons::RADIO),
     (Page::Storage, "Storage", icons::DATABASE),
 ];
 
@@ -1327,10 +1327,9 @@ impl SettingsWindow {
             ))
     }
 
-    /// The Scrobbling page: the last.fm account section - the user's own
-    /// api credentials, the connect flow, the connection readout - and
-    /// the scrobbling knobs under it.
-    fn scrobbling_page(&self, cx: &mut Context<Self>) -> Div {
+    /// The Integrations page: Last.fm account & scrobbling settings,
+    /// and Discord Rich Presence knobs.
+    fn integrations_page(&self, cx: &mut Context<Self>) -> Div {
         let scrobbler = self.scrobbler.read(cx);
         let config = scrobbler.config().clone();
         let phase = scrobbler.phase().clone();
@@ -2374,7 +2373,7 @@ impl Render for SettingsWindow {
                 Page::Workspace => self.workspace_page(cx),
                 Page::Library => self.library_page(cx),
                 Page::Providers => self.providers_page(cx),
-                Page::Scrobbling => self.scrobbling_page(cx),
+                Page::Integrations => self.integrations_page(cx),
                 Page::Storage => self.storage_page(cx),
             };
 

--- a/crates/rox/src/settings/window.rs
+++ b/crates/rox/src/settings/window.rs
@@ -33,6 +33,7 @@ use crate::assets::icons;
 use crate::backdrop::{NowPlayingArt, WindowBackdrop};
 use crate::design::palette::{self, Palette, Role, ROLES};
 use crate::design::tokens;
+use crate::integrations::discord::DiscordPresence;
 use crate::integrations::tray;
 use crate::lastfm::{self, AuthPhase, Scrobbler};
 use crate::panel::{self, AppState, ScrubState};
@@ -239,6 +240,10 @@ struct SettingsWindow {
     /// credential edits, the connect flow, and the knobs all go through
     /// it, and it persists them.
     scrobbler: Entity<Scrobbler>,
+    discord: Entity<DiscordPresence>,
+    discord_enabled: bool,
+    discord_show_timestamps: bool,
+    discord_show_details: bool,
     /// The api credential inputs; edits mirror into the scrobbler per
     /// keystroke, the pickers' cadence.
     lastfm_key: Entity<InputState>,
@@ -442,6 +447,10 @@ impl SettingsWindow {
             player,
             thumbs: state.thumbs,
             scrobbler,
+            discord: state.discord.clone(),
+            discord_enabled: settings.discord.enabled,
+            discord_show_timestamps: settings.discord.show_timestamps,
+            discord_show_details: settings.discord.show_details,
             lastfm_key,
             lastfm_secret,
             threshold_scrub: ScrubState::default(),
@@ -584,6 +593,27 @@ impl SettingsWindow {
         settings::set_quit_to_tray(on);
         Settings::update(move |s| s.quit_to_tray = on);
         tray::sync(cx);
+        cx.notify();
+    }
+
+    fn set_discord_enabled(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.discord_enabled = on;
+        Settings::update(move |s| s.discord.enabled = on);
+        self.discord.update(cx, |d, _| d.reload_config());
+        cx.notify();
+    }
+
+    fn set_discord_show_timestamps(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.discord_show_timestamps = on;
+        Settings::update(move |s| s.discord.show_timestamps = on);
+        self.discord.update(cx, |d, _| d.reload_config());
+        cx.notify();
+    }
+
+    fn set_discord_show_details(&mut self, on: bool, cx: &mut Context<Self>) {
+        self.discord_show_details = on;
+        Settings::update(move |s| s.discord.show_details = on);
+        self.discord.update(cx, |d, _| d.reload_config());
         cx.notify();
     }
 
@@ -1433,6 +1463,37 @@ impl SettingsWindow {
                                     .update(cx, |s, cx| s.set_threshold(fraction, cx));
                                 cx.notify();
                             },
+                            cx,
+                        ),
+                    )),
+            ))
+            .child(section(
+                "Discord Rich Presence",
+                None,
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(tokens::SPACE_MD)
+                    .child(panel::setting_row(
+                        "Enable Rich Presence",
+                        Some("Show rox activity on Discord when playing music"),
+                        panel::toggle(self.discord_enabled, Self::set_discord_enabled, cx),
+                    ))
+                    .child(panel::setting_row(
+                        "Show Song Progress",
+                        Some("Display live progress bar and elapsed/duration timestamps"),
+                        panel::toggle(
+                            self.discord_show_timestamps,
+                            Self::set_discord_show_timestamps,
+                            cx,
+                        ),
+                    ))
+                    .child(panel::setting_row(
+                        "Show Song & Artist Details",
+                        Some("Include track title, artist, and album name in Discord activity"),
+                        panel::toggle(
+                            self.discord_show_details,
+                            Self::set_discord_show_details,
                             cx,
                         ),
                     )),

--- a/crates/rox/src/workspace.rs
+++ b/crates/rox/src/workspace.rs
@@ -32,6 +32,7 @@ use crate::backdrop::{NowPlayingArt, WindowBackdrop};
 use crate::composite;
 use crate::design::{palette, tokens};
 use crate::history::{History, HistoryEvent};
+use crate::integrations::discord::DiscordPresence;
 use crate::integrations::media_controls::{MediaCommand, MediaKeys, NowPlayingMeta};
 use crate::integrations::tray;
 use crate::lastfm::Scrobbler;
@@ -1182,10 +1183,12 @@ impl Workspace {
             let player = cx.new(Player::new);
             let library = cx.new(Library::new);
             let scrobbler = cx.new(|cx| Scrobbler::new(&player, &library, cx));
+            let discord = cx.new(|cx| DiscordPresence::new(&player, &library, cx));
             AppState {
                 thumbs: cx.new(|cx| Thumbs::new(&library, cx)),
                 history: cx.new(|cx| History::new(&scrobbler, cx)),
                 scrobbler,
+                discord,
                 library,
                 now_art: cx.new(|cx| NowPlayingArt::new(player.clone(), cx)),
                 player,


### PR DESCRIPTION
Hey hey, got discord rich presence working!

Built on Windows 11, macOS Golden Gate (dev beta), and Arch Linux, and worked on all platforms.

It's currently running under my application ID, but feel free to register one under your account and chuck it in the top of discord.rs. You'll need to add a rich presence 'art asset' called `app_icon` (only used as a fallback if album art cannot be found), `play`, and `pause`. I can send you the icons I've used if you need them, I haven't put them in the repo.

Also adds last.fm as an album art source both for rich presence and editing cover art, as I found some of my music was eclectic enough to not have art on iTunes or Deezer....

Renamed the Scrobbling page in settings to 'Integrations' and put the settings in there.

Runs on a background executor task, and only pings Discord's IPC socket on track change, pause/resume, or manual seeks of >3s. If connection is lost, only tries to reconnect every 5 seconds so as to not spam the socket/get rate limited.
Fits and uses rox's logging, so it shows in the console window as well.

What you see viewing your own profile:
<img width="463" height="187" alt="image" src="https://github.com/user-attachments/assets/147e345a-0630-4b61-83c3-367184dc1a8e" />

What other people see:
<img width="276" height="199" alt="image" src="https://github.com/user-attachments/assets/52a5091b-0994-4236-a4a7-9fc5ec0f6f2b" />

Lmk if you need any more info! Feel free to make edits if you see fit, as well