### PR TITLE
Reduce min window size to not force micro players to be mini

### DIFF
--- a/crates/rox-core/src/settings.rs
+++ b/crates/rox-core/src/settings.rs
@@ -43,8 +43,8 @@ use crate::continuation;
 /// the clamp the programmatic resizes run through, small enough for a compact
 /// mini-player but never zero.
 pub const MIN_WINDOW_SIZE: gpui::Size<gpui::Pixels> = gpui::Size {
-    width: px(240.),
-    height: px(140.),
+    width: px(20.),
+    height: px(20.),
 };
 
 /// Where a pre-split settings file's workspaces go. The bundle handling lives


### PR DESCRIPTION
<!--
PRs are squash merged: the title becomes the commit on main, so write it like a
commit message. One logical change per PR.
-->

## What and why

To allow micro players and also barely visible windows that are only kept in the foreground without covering the screen,  e.g., for using app music controls while browsing

Closes https://github.com/zealsprince/rox/issues/101

## How it was tested

Only Run the debug build on Windows. Though for some reason the horizontal min size is still bigger despite the constraints being "square". Not sure why, is there another min config somewhere, didn't look deeper?

<img width="227" height="135" alt="rox min" src="https://github.com/user-attachments/assets/07e1d78b-8b87-44c7-b7fb-d3d20b9f89a4" />
